### PR TITLE
uws package has been deprecated

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -27,7 +27,7 @@ module.exports = appInfo => {
 
   config.io = {
     init: {
-      wsEngine: 'uws',
+      wsEngine: 'ws',
     }, // passed to engine.io
     namespace: {
       '/': {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "egg-scripts": "^2.5.0",
     "egg-socket.io": "^4.0.7",
     "egg-view-nunjucks": "^2.2.0",
-    "uws": "^9.14.0"
+    "ws": "^6.0.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",


### PR DESCRIPTION
`uws` instead of `ws`，because `uws` package has been deprecated. The test found it could not work.